### PR TITLE
Fix issues with set-uri and improve URIComboBox.set_uri

### DIFF
--- a/hab_gui/cli.py
+++ b/hab_gui/cli.py
@@ -92,13 +92,16 @@ def set_uri(settings, uri):
     # TODO: Use fancy hab-gui widgets configured by site
     current_uri = settings.resolver.user_prefs().uri
     uris = list(settings.resolver.dump_forest(settings.resolver.configs, indent=""))
-    if current_uri not in uris:
+    if current_uri and current_uri not in uris:
         uris.append(current_uri)
-    uris.sort()
-    current = uris.index(current_uri)
+    uris.sort(key=lambda i: i.lower())
+
+    current_index = -1
+    if current_uri:
+        current_index = uris.index(current_uri)
 
     uri, ok = QInputDialog.getItem(
-        None, "Set hab URI", "Set default hab URI to:", uris, current=current
+        None, "Set hab URI", "Set default hab URI to:", uris, current=current_index
     )
     if ok:
         settings.resolver.user_prefs().uri = uri

--- a/hab_gui/widgets/uri_combobox.py
+++ b/hab_gui/widgets/uri_combobox.py
@@ -40,4 +40,10 @@ class URIComboBox(QtWidgets.QComboBox):
         return self.currentText()
 
     def set_uri(self, uri):
-        self.setEditText(uri)
+        # If the uri is already an item in the combo box, select it
+        index = self.findText(uri)
+        if index > -1:
+            self.setCurrentIndex(index)
+        else:
+            # Otherwise update the text of the combo box to match
+            self.setEditText(uri)


### PR DESCRIPTION
- If the user hasn't saved any [hab user-prefs](https://github.com/blurstudio/hab#user-prefs) yet, `hab gui set-uri` would raise:
`TypeError: '<' not supported between instances of 'NoneType' and 'str'`.
- `hab gui set-uri` now sorts URI's ignoring case.
- `URIComboBox.set_uri` now selects the URI if it already exists. This makes it so when opening the combo box popup, it will scroll to the selected URI instead of staying at the top of the list.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://github.com/PyCQA/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
