### PR TITLE
Add entry_point support for AliasLaunchWindow

### DIFF
--- a/hab_gui/widgets/alias_button.py
+++ b/hab_gui/widgets/alias_button.py
@@ -1,7 +1,6 @@
 import logging
-import os
 
-from Qt import QtCore, QtGui, QtWidgets
+from Qt import QtCore, QtWidgets
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +23,6 @@ class AliasButton(QtWidgets.QToolButton):
         self.alias_name = alias_name
 
         self.alias_dict = self.cfg.aliases
-        self.setToolButtonStyle(QtCore.Qt.ToolButtonTextBesideIcon)
         qsize_policy = QtWidgets.QSizePolicy
         size_policy = qsize_policy(qsize_policy.Minimum, qsize_policy.Preferred)
         self.setSizePolicy(size_policy)
@@ -37,15 +35,5 @@ class AliasButton(QtWidgets.QToolButton):
 
     def refresh(self):
         alias = self.alias_dict[self.alias_name]
-        icon = QtGui.QIcon()
-        icon_path = alias.get("icon", "")
-        if os.path.exists(icon_path):
-            icon.addPixmap(QtGui.QPixmap(icon_path))
-        elif icon_path:
-            logger.debug(
-                f"The specified icon file {icon_path} does not exist for {self.alias_dict}"
-            )
-        self.setIcon(icon)
-
         label = alias.get("label", self.alias_name)
         self.setText(label)

--- a/hab_gui/widgets/alias_button_grid.py
+++ b/hab_gui/widgets/alias_button_grid.py
@@ -2,7 +2,7 @@ import hab
 from Qt import QtWidgets
 
 from .. import utils
-from .alias_button import AliasButton
+from .alias_icon_button import AliasIconButton
 
 
 class AliasButtonGrid(QtWidgets.QWidget):
@@ -29,7 +29,7 @@ class AliasButtonGrid(QtWidgets.QWidget):
         button_layout,
         verbosity,
         uri=None,
-        button_cls=AliasButton,
+        button_cls=AliasIconButton,
         parent=None,
     ):
         super().__init__(parent)

--- a/hab_gui/widgets/alias_icon_button.py
+++ b/hab_gui/widgets/alias_icon_button.py
@@ -1,0 +1,39 @@
+import logging
+import os
+
+from Qt import QtCore, QtGui
+
+from .alias_button import AliasButton
+
+logger = logging.getLogger(__name__)
+
+
+class AliasIconButton(AliasButton):
+    """Create a AliasButton that also shows a icon for each alias.
+
+    Args:
+        cfg (hab.parsers.flat_config.FlatConfig): The config object which contains
+        URI related data.
+        alias_name (str): The alias name passed from AliasButtonGrid.
+        parent (Qt.QtWidgets.QWidget, optional): Define a parent for this widget.
+    """
+
+    button_pressed = QtCore.Signal(str)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setToolButtonStyle(QtCore.Qt.ToolButtonTextBesideIcon)
+
+    def refresh(self):
+        alias = self.alias_dict[self.alias_name]
+        icon = QtGui.QIcon()
+        icon_path = alias.get("icon", "")
+        if os.path.exists(icon_path):
+            icon.addPixmap(QtGui.QPixmap(icon_path))
+        elif icon_path:
+            logger.debug(
+                f"The specified icon file {icon_path} does not exist for {self.alias_dict}"
+            )
+        self.setIcon(icon)
+
+        super().refresh()

--- a/hab_gui/widgets/uri_line_edit.py
+++ b/hab_gui/widgets/uri_line_edit.py
@@ -6,14 +6,16 @@ class URILineEdit(QtWidgets.QLineEdit):
 
     Args:
         resolver (hab.Resolver): The resolver to pull the URI data from Hab.
+        verbosity (int): Pass along a verbosity value for filtering of URIs
         parent (Qt.QtWidgets.QWidget, optional): Define a parent for this widget.
     """
 
     uri_changed = QtCore.Signal(str)
 
-    def __init__(self, resolver, parent=None):
+    def __init__(self, resolver, verbosity=0, parent=None):
         super().__init__(parent)
         self.resolver = resolver
+        self.verbosity = verbosity
 
         self.setPlaceholderText("Enter a URI...")
         self.textChanged.connect(self._emit_uri_changed)

--- a/tests/site/hab-gui-alt.json
+++ b/tests/site/hab-gui-alt.json
@@ -1,0 +1,21 @@
+{
+    "prepend": {
+        "entry_points": {
+            "cli": {
+                "gui": "hab_gui.cli:gui"
+            },
+            "hab_gui_uri_widget": {
+                "uri_widget": "hab_gui.widgets.uri_line_edit:URILineEdit"
+            },
+            "hab_gui_alias_widget": {
+                "uri_widget": "hab_gui.widgets.alias_button:AliasButton"
+            },
+            "hab_gui_uri_pin_widget": {
+                "uri_widget": null
+            }
+        }
+    },
+    "set": {
+        "prefs_default": "--prefs"
+    }
+}


### PR DESCRIPTION
Makes it so site config's can load custom widgets in AliasLaunchWindow.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://github.com/PyCQA/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
