### PR TITLE
Improve the error message box display

### DIFF
--- a/hab_gui/cli.py
+++ b/hab_gui/cli.py
@@ -46,6 +46,11 @@ def get_application(settings=None, splash=True, **kwargs):
                 _splash = SplashScreen(splash_image)
                 _splash.show()
 
+        # For a consistent UI, set the window icon for the application. All top
+        # level widgets will inherit this automatically unless they override
+        # it themselves.
+        app.setWindowIcon(utils.Paths.icon("habihat.svg"))
+
     return app, _splash
 
 

--- a/hab_gui/dialogs/error_message_box.py
+++ b/hab_gui/dialogs/error_message_box.py
@@ -1,0 +1,75 @@
+import traceback
+
+from pygments import highlight
+from pygments.formatters import HtmlFormatter
+from pygments.lexers import PythonLexer
+from Qt import QtCore, QtWidgets
+
+
+class ErrorMessageBox(QtWidgets.QMessageBox):
+    """QMessageBox that shows a manageable, highlighted python traceback.
+
+    If the traceback is longer than the short version, then the full traceback
+    is shown in more details section. It also adds a button to easily copy the
+    full raw traceback text.
+    """
+
+    def __init__(self, etype, value, tb, parent=None):
+        super().__init__(parent=parent)
+        self._raw_traceback = None
+        self.etype = etype
+        self.value = value
+        self.tb = tb
+        # Limit the length of the traceback to the last X results.
+        self.stack_limit = -5
+
+        self.setWindowTitle("Exception")
+        self.setTextFormat(QtCore.Qt.RichText)
+        self.setStandardButtons(QtWidgets.QMessageBox.Ok)
+        # Using detailedText seems to disable the close button, enable it
+        self.setEscapeButton(QtWidgets.QMessageBox.Ok)
+
+        # Create a button allowing the user to copy the non-highlighted text
+        copy_btn = self.addButton("Copy", QtWidgets.QMessageBox.ActionRole)
+        copy_btn.setToolTip("Copy the full traceback for error reporting.")
+        # Disconnect the QMessageBox signals that would cause the box to close
+        # when this button is pressed and add our own signal connection
+        copy_btn.disconnect()
+        copy_btn.released.connect(self.copy_traceback)
+
+        self.setDefaultButton(QtWidgets.QMessageBox.Ok)
+        self.refresh()
+
+    @QtCore.Slot()
+    def copy_traceback(self):
+        """Copy the raw traceback into the copy paste buffer."""
+        text = self._raw_traceback
+        QtWidgets.QApplication.clipboard().setText(text)
+
+    def highlight(self, text):
+        """Syntax highlight the traceback to make it more readable."""
+        fhtml = HtmlFormatter()
+        body = highlight(text, PythonLexer(), fhtml)
+        style = fhtml.get_style_defs()
+        return f"<head><style>{style}</style></head>{body}"
+
+    def refresh(self):
+        short = None
+        full = traceback.format_exception(self.etype, self.value, self.tb)
+        # If the traceback is longer than stack_limit, then show a short tb
+        # in the message box and include the full traceback in detailed text
+        if len(full) - 2 > abs(self.stack_limit):
+            # Subtract two to account for first and last line of a traceback.
+            # Each file line in the list includes the python code on the next line.
+            short = traceback.format_exception(
+                self.etype, self.value, self.tb, limit=self.stack_limit
+            )
+            short = "".join(short)
+
+        self._raw_traceback = "".join(full)
+        if short:
+            self.setText(self.highlight(short))
+            self.setDetailedText(self._raw_traceback)
+        else:
+            self.setText(self.highlight(self._raw_traceback))
+            self.setDetailedText("")

--- a/hab_gui/entry_points/message_box.py
+++ b/hab_gui/entry_points/message_box.py
@@ -1,5 +1,4 @@
 import logging
-import traceback
 
 from .logging_exception import LoggingExceptionInit
 
@@ -15,9 +14,7 @@ class MessageBoxInit(LoggingExceptionInit):
     def excepthook(self, cls, exception, tb):
         super().excepthook(cls, exception, tb)
 
-        from Qt.QtWidgets import QMessageBox
+        from ..dialogs.error_message_box import ErrorMessageBox
 
-        # Show the user that an exception happened.
-        msg = traceback.format_exception(cls, exception, tb)
-        msg = "".join(msg)
-        QMessageBox.critical(None, "Exception", msg)
+        box = ErrorMessageBox(cls, exception, tb, parent=None)
+        box.exec_()

--- a/hab_gui/widgets/alias_button_grid.py
+++ b/hab_gui/widgets/alias_button_grid.py
@@ -1,4 +1,5 @@
 import hab
+from hab.errors import InvalidRequirementError
 from Qt import QtWidgets
 
 from .. import utils
@@ -48,7 +49,16 @@ class AliasButtonGrid(QtWidgets.QWidget):
         self.clear()
         if self.uri is None:
             return
-        cfg = self.resolver.resolve(self.uri)
+        try:
+            cfg = self.resolver.resolve(self.uri)
+        except InvalidRequirementError as error:
+            msg = f"Error resolving URI: {self.uri}"
+            label = QtWidgets.QLabel()
+            label.setText(f"{msg}\n\n{error}")
+            label.setWordWrap(True)
+            self.grid_layout.addWidget(label)
+            raise
+
         with hab.utils.verbosity_filter(self.resolver, self.verbosity):
             alias_list = list(cfg.aliases.keys())
             # So buttons show up in alphabetical order

--- a/hab_gui/widgets/custom_variable_editor/custom_variable_editor.py
+++ b/hab_gui/widgets/custom_variable_editor/custom_variable_editor.py
@@ -28,7 +28,6 @@ class CustomVariableEditor(QtWidgets.QWidget):
         self.resolver = resolver
         self.verbosity = verbosity
         utils.load_ui(__file__, self)
-        self.setWindowIcon(utils.Paths.icon("habihat.svg"))
 
         self.uiAddVariableBTN.setIcon(utils.Paths.icon("plus-thick.svg"))
         self.uiEditCurrentItemBTN.setIcon(utils.Paths.icon("pencil-box-outline.svg"))

--- a/hab_gui/windows/alias_launch_window.py
+++ b/hab_gui/windows/alias_launch_window.py
@@ -131,8 +131,6 @@ class AliasLaunchWindow(QtWidgets.QMainWindow):
         )
 
     def init_gui(self, uri=None):
-        self.setWindowIcon(utils.Paths.icon("habihat.svg"))
-
         self.main_widget = QtWidgets.QWidget()
         self.layout = QtWidgets.QGridLayout()
 

--- a/hab_gui/windows/alias_launch_window.py
+++ b/hab_gui/windows/alias_launch_window.py
@@ -177,8 +177,10 @@ class AliasLaunchWindow(QtWidgets.QMainWindow):
         if uri is None:
             uri = str(self.resolver.user_prefs().uri_check())
         if uri:
-            self.uri_widget.set_uri(uri)
-            self.uri_changed(uri)
+            # This QTimer allows the gui to stay open even if the URI can't
+            # be resolved. For example if the URI depends on a distro that is
+            # no longer installed.
+            QtCore.QTimer.singleShot(0, partial(self.uri_widget.set_uri, uri))
 
         # Ensure the URI widget has focus by default
         self.uri_widget.setFocus()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,9 @@ classifiers = [
 ]
 requires-python = ">=3.6"
 dependencies = [
+    "click>=7.1.2",
     "hab>=0.27.0",
+    "Pygments",
     "Qt.py",
     ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 click>=7.1.2
-hab>=0.22.0
+hab>=0.27.0
+Pygments
+Qt.py


### PR DESCRIPTION
Make the error QMesssageBox more user friendly, and improve the user experience when running into an invalid requirement error.

Fixes a few issues.
1. The QMessageBox shown was often taller than the screen making it hard to see the bottom of the dialog. It will now only show the last 5 stack items in the traceback. You can use the show details button to show the full traceback, or use the copy button.
2. The short traceback shown in the message box has basic syntax highlighting.
3. The UI will no longer close if encountering an error on init. Now adds a message explaining why there are no aliases when encountering a InvalidRequirementError.

![python_vo5ryO0lUI](https://github.com/blurstudio/hab-gui/assets/2424292/5568f2e9-e035-493c-b52e-bbae59e55ad9)

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://github.com/PyCQA/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
