### PR TITLE
Add a menu for controlling verbosity

### DIFF
--- a/hab_gui/actions/edit_custom_variables_action.py
+++ b/hab_gui/actions/edit_custom_variables_action.py
@@ -12,30 +12,24 @@ class EditCustomVariablesAction(QtWidgets.QAction):
     then add or remove variables, and edit their keys and values.
 
     Args:
-        resolver (hab.Resolver): The resolver used for settings.
-        hab_widget (QWidget): The URI widget menu operations are performed on.
-        verbosity (int, optional): The current verbosity setting.
+        settings (hab_gui.settings.Settings): Used to access shared hab settings.
         parent (Qt.QtWidgets.QWidget, optional): Define a parent for this widget.
     """
 
-    def __init__(self, resolver, hab_widget, verbosity=0, parent=None):
+    def __init__(self, settings, parent=None):
         super().__init__(
             utils.Paths.icon("pencil-box-outline.svg"),
             "Edit Custom Variables",
             parent,
         )
-        self.hab_widget = hab_widget
-        self.resolver = resolver
-        self.verbosity = verbosity
+        self.settings = settings
         self.setObjectName("edit_custom_variables")
 
         self.triggered.connect(self.edit_custom_variables)
 
     def edit_custom_variables(self):
-        dlg = CustomVariableEditor.create_dialog(
-            self.resolver, verbosity=self.verbosity, parent=self.parent()
-        )
+        dlg = CustomVariableEditor.create_dialog(self.settings, parent=self.parent())
         dlg.exec_()
 
         # Ensure the hab_gui respects any changes the user may have made
-        self.hab_widget.refresh_cache()
+        self.settings.root_widget.refresh_cache()

--- a/hab_gui/actions/refresh_action.py
+++ b/hab_gui/actions/refresh_action.py
@@ -4,24 +4,20 @@ from .. import utils
 
 
 class RefreshAction(QtWidgets.QAction):
-    """A QAction that causes the hab_widget to refresh the resolved hab setup and UI.
+    """A QAction that causes the root_widget to refresh the resolved hab and UI.
 
     Args:
-        resolver (hab.Resolver): The resolver used for settings.
-        hab_widget (QWidget): The URI widget menu operations are performed on.
-        verbosity (int, optional): The current verbosity setting.
+        settings (hab_gui.settings.Settings): Used to access shared hab settings.
         parent (Qt.QtWidgets.QWidget, optional): Define a parent for this widget.
     """
 
-    def __init__(self, resolver, hab_widget, verbosity=0, parent=None):
+    def __init__(self, settings, parent=None):
         super().__init__(
             utils.Paths.icon("refresh.svg"),
             "Refresh Hab Config",
             parent,
         )
-        self.hab_widget = hab_widget
-        self.resolver = resolver
-        self.verbosity = verbosity
+        self.settings = settings
         self.setObjectName("refresh_hab_cfg")
 
-        self.triggered.connect(self.hab_widget.refresh_cache)
+        self.triggered.connect(self.settings.root_widget.refresh_cache)

--- a/hab_gui/actions/separator_action.py
+++ b/hab_gui/actions/separator_action.py
@@ -5,12 +5,10 @@ class SeparatorAction(QtWidgets.QAction):
     """A entry point used to add a separator to a menu using entry_points.
 
     Args:
-        resolver (hab.Resolver): Ignored for this class.
-        hab_widget (QWidget): Ignored for this class.
-        verbosity (int, optional): Ignored for this class.
+        settings (hab_gui.settings.Settings): Used to access shared hab settings.
         parent (Qt.QtWidgets.QWidget, optional): Define a parent for this widget.
     """
 
-    def __init__(self, resolver, hab_widget, verbosity=0, parent=None):
+    def __init__(self, settings, parent=None):
         super().__init__(parent)
         self.setSeparator(True)

--- a/hab_gui/actions/verbosity_action.py
+++ b/hab_gui/actions/verbosity_action.py
@@ -1,0 +1,77 @@
+from Qt import QtCore, QtWidgets
+
+
+class VerbosityAction(QtWidgets.QAction):
+    """A QAction that allows the user to modify hab verbosity inside the gui.
+
+    This action has a sub-menu that lists the available verbosity settings, the
+    current setting and lets the user change the verbosity setting.
+
+    You can customize the name of this widget and it's sub-menu names by adding
+    a `verbosity_action` dictionary to your site config matching
+    :py:attr:`default_config`'s structure.
+
+    See :py:attr:`Settings.verbosity` for details on how this is saved to user_prefs.
+
+    Args:
+        settings (hab_gui.settings.Settings): Used to access shared hab settings.
+        parent (Qt.QtWidgets.QWidget, optional): Define a parent for this widget.
+    """
+
+    default_config = {
+        "name": "Set Verbosity",
+        "verbosity_map": {
+            "Off": 0,
+            "Low": 1,
+            "Medium": 2,
+            "High": 3,
+        },
+    }
+    """dict: Default settings for this widget. `name` defines the name of the
+    action containing the sub-menu. `verbosity_map` is a mapping of nice names
+    for verbosity int value. This dict is used to build the sub-menu.
+    """
+
+    def __init__(self, settings, parent=None):
+        super().__init__(parent)
+        self.settings = settings
+        self.settings.verbosity_changed.connect(self.refresh)
+        self.setObjectName("edit_verbosity")
+
+        self.load_config()
+        self.setText(self.name)
+        # Build a sub-menu letting the user view and update verbosity
+        menu = QtWidgets.QMenu("Verbosity", self.settings.root_widget)
+        menu.triggered.connect(self.menu_triggered)
+        verbosity = self.settings.verbosity
+        for key, value in self.verbosity_map.items():
+            action = menu.addAction(key)
+            action.setData(value)
+            action.setCheckable(True)
+            if verbosity == value:
+                action.setChecked(QtCore.Qt.Checked)
+            else:
+                action.setChecked(QtCore.Qt.Unchecked)
+        self.setMenu(menu)
+
+    def load_config(self):
+        site = self.settings.resolver.site
+        settings = site.get("verbosity_action", {})
+        self.name = settings.get("name", self.default_config["name"])
+        self.verbosity_map = settings.get(
+            "verbosity_map", self.default_config["verbosity_map"]
+        )
+
+    def menu_triggered(self, action):
+        """Handles all actions selected by the user in the menu."""
+        self.settings.verbosity = action.data()
+
+    def refresh(self):
+        """Updates currently checked item in the sub-menu"""
+        verbosity = self.settings.verbosity
+        for action in self.menu().actions():
+            value = action.data()
+            if verbosity == value:
+                action.setChecked(QtCore.Qt.Checked)
+            else:
+                action.setChecked(QtCore.Qt.Unchecked)

--- a/hab_gui/cli.py
+++ b/hab_gui/cli.py
@@ -72,6 +72,7 @@ def gui(ctx):
 @click.pass_obj
 def launch(settings, verbosity, uri):
     """Show a gui letting the user launch applications."""
+    from .settings import Settings
     from .windows.alias_launch_window import AliasLaunchWindow
 
     if isinstance(uri, click.UsageError):
@@ -83,7 +84,8 @@ def launch(settings, verbosity, uri):
 
     settings.resolver._verbosity_target = "hab-gui"
 
-    window = AliasLaunchWindow(settings.resolver, uri=uri, verbosity=verbosity)
+    s = Settings(settings.resolver, verbosity, uri=uri)
+    window = AliasLaunchWindow(s)
     window.show()
     if splash:
         splash.finish(window)

--- a/hab_gui/settings.py
+++ b/hab_gui/settings.py
@@ -1,0 +1,44 @@
+from Qt.QtCore import QObject, Signal
+
+
+class Settings(QObject):
+    """A collection shared hab gui settings passed to widgets.
+
+    Args:
+        resolver (hab.Resolver): The hab resolver to get information from.
+        verbosity (int): Change the verbosity setting to this value. If None is
+            passed, all results are be shown without any filtering.
+        uri (str, optional): Use this as the current URI.
+        root_widget (Qt.QtWidgets.QWidget, optional): The main Qt widget, likely
+            a top level widget. For example `AliasLaunchWindow`.
+    """
+
+    verbosity_changed = Signal(int)
+    """Signal emitted any time the verbosity property is updated, passing the new value."""
+    uri_changed = Signal(str)
+    """Signal emitted any time the URI is updated, passing the new URI."""
+
+    def __init__(self, resolver, verbosity, uri=None, root_widget=None, parent=None):
+        super().__init__(parent=parent)
+        self._verbosity = verbosity
+        self._uri = uri
+        self.resolver = resolver
+        self.root_widget = root_widget
+
+    @property
+    def verbosity(self):
+        return self._verbosity
+
+    @verbosity.setter
+    def verbosity(self, value):
+        self._verbosity = value
+        self.verbosity_changed.emit(value)
+
+    @property
+    def uri(self):
+        return self._uri
+
+    @uri.setter
+    def uri(self, uri):
+        self._uri = uri
+        self.uri_changed.emit(uri)

--- a/hab_gui/settings.py
+++ b/hab_gui/settings.py
@@ -1,4 +1,8 @@
+import logging
+
 from Qt.QtCore import QObject, Signal
+
+logger = logging.getLogger(__name__)
 
 
 class Settings(QObject):
@@ -27,12 +31,30 @@ class Settings(QObject):
 
     @property
     def verbosity(self):
+        """The verbosity setting used by hab_gui.
+
+        This can be passed using `hab gui launch -v`. If the site configuration
+        variable `prefs_save_verbosity` is set to `true`(the default) and user_prefs
+        are enabled, then when this variable is modified, its state will be saved
+        in the user_prefs.
+        """
         return self._verbosity
 
     @verbosity.setter
     def verbosity(self, value):
         self._verbosity = value
         self.verbosity_changed.emit(value)
+
+        # If enabled save the user preference for verbosity
+        if not self.resolver.site.get("prefs_save_verbosity", True):
+            return
+
+        user_prefs = self.resolver.user_prefs()
+        if user_prefs.enabled:
+            user_prefs.load()
+            user_prefs.setdefault("verbosity", {})["hab-gui"] = value
+            user_prefs.save()
+            logger.warning(f"User prefs verbosity saved to {user_prefs.filename}")
 
     @property
     def uri(self):

--- a/hab_gui/widgets/alias_button_grid.py
+++ b/hab_gui/widgets/alias_button_grid.py
@@ -40,6 +40,7 @@ class AliasButtonGrid(QtWidgets.QWidget):
 
         # Update this widget any time settings are updated
         self.settings.uri_changed.connect(self.refresh)
+        self.settings.verbosity_changed.connect(self.refresh)
 
     def refresh(self):
         self.clear()

--- a/hab_gui/widgets/menu_button.py
+++ b/hab_gui/widgets/menu_button.py
@@ -19,18 +19,13 @@ class MenuButton(QtWidgets.QToolButton):
     actions like `SeparatorAction`, make sure they all have unique names.
 
     Args:
-        resolver (hab.Resolver): The resolver used for settings.
-        hab_widget (QWidget): The URI widget menu operations are performed on.
-            This likely is also the parent, but may not be.
-        verbosity (int): Pass along a verbosity value for filtering of URIs
+        settings (hab_gui.settings.Settings): Used to access shared hab settings.
         parent (Qt.QtWidgets.QWidget, optional): Define a parent for this widget.
     """
 
-    def __init__(self, resolver, hab_widget, verbosity=0, parent=None):
+    def __init__(self, settings, parent=None):
         super().__init__(parent=parent)
-        self.hab_widget = hab_widget
-        self.resolver = resolver
-        self.verbosity = verbosity
+        self.settings = settings
 
         self.setText("Menu")
         self.setIcon(utils.Paths.icon("menu.svg"))
@@ -55,12 +50,12 @@ class MenuButton(QtWidgets.QToolButton):
 
     def populate_menu(self, menu):
         """Builds the menu by adding QActions defined by the entry_points."""
-        eps = self.resolver.site.entry_points_for_group(
+        eps = self.settings.resolver.site.entry_points_for_group(
             self.entry_point_name, default=self.entry_point_default
         )
         for ep in eps:
             cls = ep.load()
-            act = cls(resolver=self.resolver, hab_widget=self.hab_widget, parent=self)
+            act = cls(settings=self.settings, parent=self)
             menu.addAction(act)
 
     def refresh(self):

--- a/hab_gui/widgets/pinned_uris_button.py
+++ b/hab_gui/widgets/pinned_uris_button.py
@@ -13,10 +13,9 @@ class PinnedUriButton(QtWidgets.QToolButton):
     from previously saved URI's or add/remove a URI to saved user_prefs.
 
     Args:
-        resolver (hab.Resolver): The resolver used for settings.
+        settings (hab_gui.settings.Settings): Used to access shared hab settings.
         uri_widget (QWidget): The URIComboBox like widget used to get/set the
             current URI from.
-        verbosity (int): Pass along a verbosity value for filtering of URIs
         parent (Qt.QtWidgets.QWidget, optional): Define a parent for this widget.
     """
 
@@ -24,11 +23,10 @@ class PinnedUriButton(QtWidgets.QToolButton):
     _text_pin_selected = "Pin selected URI"
     _text_remove_uri = "Remove pin"
 
-    def __init__(self, resolver, uri_widget, verbosity=0, parent=None):
+    def __init__(self, settings, uri_widget, parent=None):
         super().__init__(parent)
-        self.resolver = resolver
+        self.settings = settings
         self.uri_widget = uri_widget
-        self.verbosity = verbosity
 
         self.setToolTip("Select and manage quick access to commonly used URI's.")
         self.setText(self._text_main)
@@ -91,7 +89,7 @@ class PinnedUriButton(QtWidgets.QToolButton):
         that if prefs are enabled. Returns `set()` otherwise. This will call load
         to ensure the preference file has been loaded.
         """
-        prefs = self.resolver.user_prefs()
+        prefs = self.settings.resolver.user_prefs()
         if prefs.enabled:
             # Ensure the preferences are loaded.
             prefs.load()
@@ -102,7 +100,7 @@ class PinnedUriButton(QtWidgets.QToolButton):
         """Saves URIS to pinned_uris in user_prefs. It will only do that if prefs
         are enabled. This will call load to ensure the preference file has been loaded.
         """
-        prefs = self.resolver.user_prefs()
+        prefs = self.settings.resolver.user_prefs()
         if prefs.enabled:
             # Ensure the preferences are loaded.
             prefs.load()

--- a/hab_gui/widgets/uri_combobox.py
+++ b/hab_gui/widgets/uri_combobox.py
@@ -6,35 +6,32 @@ class URIComboBox(QtWidgets.QComboBox):
     """Create a QComboBox to store a given list of URIs.
 
     Args:
-        resolver (hab.Resolver): The resolver to pull the URI data from Hab.
-        verbosity (int): Pass along a verbosity value for filtering of URIs
+        settings (hab_gui.settings.Settings): Used to access shared hab settings.
         parent (Qt.QtWidgets.QWidget, optional): Define a parent for this widget.
     """
 
-    uri_changed = QtCore.Signal(str)
-
-    def __init__(self, resolver, verbosity=0, parent=None):
+    def __init__(self, settings, parent=None):
         super().__init__(parent)
-        self.resolver = resolver
-        self.verbosity = verbosity
+        self.settings = settings
         self.setEditable(True)
         _translate = QtCore.QCoreApplication.translate
         self.setPlaceholderText(_translate("Launch_Aliases", "Select a URI..."))
         self.lineEdit().setPlaceholderText(self.placeholderText())
         self.refresh()
 
-        self.currentTextChanged.connect(self._emit_uri_changed)
+        self.currentTextChanged.connect(self._uri_changed)
 
-    def _emit_uri_changed(self):
-        self.uri_changed.emit(self.uri())
+    def _uri_changed(self):
+        self.settings.uri = self.uri()
 
     def refresh(self):
         current = self.uri()
         self.clear()
         if self.uri is None:
             return
-        with hab.utils.verbosity_filter(self.resolver, self.verbosity):
-            items = self.resolver.dump_forest(self.resolver.configs, indent="")
+        resolver = self.settings.resolver
+        with hab.utils.verbosity_filter(resolver, self.settings.verbosity):
+            items = resolver.dump_forest(resolver.configs, indent="")
             self.addItems(items)
         self.set_uri(current)
 

--- a/hab_gui/widgets/uri_line_edit.py
+++ b/hab_gui/widgets/uri_line_edit.py
@@ -1,27 +1,23 @@
-from Qt import QtCore, QtWidgets
+from Qt import QtWidgets
 
 
 class URILineEdit(QtWidgets.QLineEdit):
     """Create a QLineEdit to store a given list of URIs.
 
     Args:
-        resolver (hab.Resolver): The resolver to pull the URI data from Hab.
-        verbosity (int): Pass along a verbosity value for filtering of URIs
+        settings (hab_gui.settings.Settings): Used to access shared hab settings.
         parent (Qt.QtWidgets.QWidget, optional): Define a parent for this widget.
     """
 
-    uri_changed = QtCore.Signal(str)
-
-    def __init__(self, resolver, verbosity=0, parent=None):
+    def __init__(self, settings, parent=None):
         super().__init__(parent)
-        self.resolver = resolver
-        self.verbosity = verbosity
+        self.settings = settings
 
         self.setPlaceholderText("Enter a URI...")
-        self.textChanged.connect(self._emit_uri_changed)
+        self.textChanged.connect(self._uri_changed)
 
-    def _emit_uri_changed(self):
-        self.uri_changed.emit(self.uri())
+    def _uri_changed(self):
+        self.settings.uri = self.uri()
 
     def refresh(self):
         # Nothing to refresh on this widget


### PR DESCRIPTION
![WindowsTerminal_aBtQqeDEhv](https://github.com/blurstudio/hab-gui/assets/2424292/deff9e44-24a6-4205-a142-e03fb66bd181)


Adds a "hab_gui.uri.menu.actions" QAction that lists verbosity settings and allows the user to change the verbosity updating the shown aliases. This allows a user to 

This can be configured by setting the "verbosity_action" dictionary in a site config file.

```json5
{
    "set": {
        "verbosity_action": {
            "name": "Visibility",
            "verbosity_map": {
                "Preferred": 0,
                "DCC Versions": 1,
                // We don't use verbosity 2 so don't show it to the user
                "Everything": 3,
            }
        }
    }
}
```

This also stores the verbosity value in user_prefs if enabled. This way a user gets the same setting the next time they open hab launcher.

### Potentially breaking change

**Who does it affect:** This is only a breaking change if you have written your own custom widgets that expect the old kwargs structure.

This re-works the kwarg's that most gui widgets use by replacing the `resolver`, `hab_widget` and `verbosity` arguments with a shared `Settings` instance. The Settings instance is a QObject allowing it to have Qt signals that widgets can connect to and respond to changes. It will also ensure that this kind of breaking change won't need to happen again as we can add new properties without the need to change the kwargs of many widgets.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://github.com/PyCQA/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
