### PR TITLE
Include the URI in AliasLaunchWindow's window title

### DIFF
--- a/hab_gui/windows/alias_launch_window.py
+++ b/hab_gui/windows/alias_launch_window.py
@@ -27,6 +27,11 @@ class AliasLaunchWindow(QtWidgets.QMainWindow):
         parent (Qt.QtWidgets.QWidget, optional): Define a parent for this widget.
     """
 
+    window_title = "Hab Launch - {uri}"
+    """The title of this window. Use a `str.format` style string with the kwarg
+    `uri` to include the currently selected URI.
+    """
+
     def __init__(
         self,
         settings,
@@ -45,7 +50,6 @@ class AliasLaunchWindow(QtWidgets.QMainWindow):
         self.init_gui(uri)
 
         # Window properties
-        self.setWindowTitle("Hab Launch Aliases")
         self.setFixedWidth(400)
         self.center_window_position()
 
@@ -61,6 +65,12 @@ class AliasLaunchWindow(QtWidgets.QMainWindow):
             refresh_time = utils.interval(refresh_time)
             logger.debug(f"Setting auto-refresh interval to {refresh_time} seconds")
             self.refresh_timer.start(refresh_time * 1000)
+
+    def _update_window_title(self, uri):
+        """Updates the window title with a `str.format` style string with the
+        kwarg `uri` to include the currently selected URI.
+        """
+        self.setWindowTitle(self.window_title.format(uri=uri))
 
     def apply_layout(self):
         """Configures the layout of all widgets in this interface."""
@@ -174,6 +184,10 @@ class AliasLaunchWindow(QtWidgets.QMainWindow):
 
         # Ensure the URI widget has focus by default
         self.uri_widget.setFocus()
+
+        # Ensure the window title always shows the currently selected URI
+        self.settings.uri_changed.connect(self._update_window_title)
+        self._update_window_title(uri)
 
     @utils.cursor_override()
     def refresh_cache(self, reset_timer=True):


### PR DESCRIPTION
## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://github.com/PyCQA/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->

Changes the hard coded window title of AliasLaunchWindow from `"Hab Launch Aliases"` to `"Hab Launch - {uri}".format(uri=uri)`. This makes it easier to alt+tab between multiple launcher windows set to different URI's.