### PR TITLE
Add a URI Picker dialog to pick uris when launching a generic shortcut

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,7 @@ instance/
 .scrapy
 
 # Sphinx documentation
-docs/_build/
+docs/
 
 # PyBuilder
 .pybuilder/

--- a/hab_gui/dialogs/uri_picker_dialog.py
+++ b/hab_gui/dialogs/uri_picker_dialog.py
@@ -1,0 +1,163 @@
+from Qt import QtCore, QtWidgets
+
+
+class UriPickerDialog(QtWidgets.QDialog):
+    """A dialog for asking the user to pick a URI only when required.
+
+    This dialog is intended to be a front end for gui based methods of launching
+    aliases. It is especially useful when using `user_prefs with timeout`_
+    to only show the dialog if the timeout has expired.
+
+    The intended workflow for this item is to create a desktop shortcut or other
+    gui based method for generically launching a alias like maya. The shortcut
+    would call `habw gui launch - maya`. If user prefs are enabled and the URI has
+    not timed out, the maya app is launched without user interaction. However if
+    the user prefs are disabled or URI has timed out, or the user is pressing the
+    shift key or the user has checked the always ask checkbox for maya, it will
+    show this dialog allowing the user to choose the URI they want to use.
+
+    Args:
+        settings (hab_gui.settings.Settings): Used to handle gui settings and
+            facilitate emitting signals when settings change.
+        alias (str, optional): The alias name the user want's to launch.
+        expired (bool, optional): The text shown to the user indicates that it
+            expired instead of simply asking the user to choose a URI.
+        parent (Qt.QtWidgets.QWidget, optional): Define a parent for this widget.
+
+    .. _user_prefs with timeout:
+        https://github.com/blurstudio/hab?tab=readme-ov-file#user-prefs
+    """
+
+    template = {
+        "label": [
+            "Saved URI expired, please update with what you are currently working on.",
+            "Choose the URI you would like to launch{_alias} with.",
+        ],
+        "title": [
+            "Pick URI to launch {alias}",
+            "Pick URI to launch",
+        ],
+    }
+    """Templates for the text shown in this dialog. `str.format` is called passing
+    the kwarg `alias` as `self.alias`. `_kwarg` is the alias with a leading space
+    if specified otherwise an empty string.
+    "label" is the informational label text, If the URI expired,
+    index 0 is used, otherwise index 1. "title" is the window title, if an alias
+    is provided index 0 is used, otherwise index 1.
+    """
+
+    def __init__(self, settings, alias=None, expired=False, parent=None):
+        super().__init__(parent=parent)
+        self.alias = alias
+        self.expired = expired
+        self.settings = settings
+        self._cls_uri_widget = self.settings.load_entry_point(
+            "hab_gui.uri.widget", "hab_gui.widgets.uri_combobox:URIComboBox"
+        )
+        self.init_gui()
+
+    def accept(self):
+        self.save_prefs()
+        super().accept()
+
+    def init_gui(self):
+        self.info_label = QtWidgets.QLabel(self)
+        self.uri_widget = self._cls_uri_widget(self.settings, parent=self)
+        self.always_ask = QtWidgets.QCheckBox(
+            "Ask on every launch (or hold shift when launching)", self
+        )
+
+        self.uiButtonsBOX = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Cancel, self
+        )
+        self.uiButtonsBOX.addButton("Launch", QtWidgets.QDialogButtonBox.AcceptRole)
+        self.uiButtonsBOX.accepted.connect(self.accept)
+        self.uiButtonsBOX.rejected.connect(self.reject)
+
+        lyt = QtWidgets.QVBoxLayout(self)
+        lyt.addWidget(self.info_label)
+        lyt.addWidget(self.uri_widget)
+        lyt.addWidget(self.always_ask)
+        lyt.addWidget(self.uiButtonsBOX)
+        self.refresh()
+
+    @classmethod
+    def prefs(cls, settings, alias):
+        """Returns a dictionary of user preference information for this dialog.
+
+        Returns:
+            enabled (bool): If user prefs are enabled.
+            user_prefs: The actual user_prefs object.
+            ask (bool, optional): If the user want's to always ask for this alias.
+        """
+        user_prefs = settings.resolver.user_prefs()
+        ret = dict(enabled=user_prefs.enabled, user_prefs=user_prefs)
+        if not user_prefs.enabled:
+            return ret
+        user_prefs.load()
+        ret["ask"] = user_prefs.get("uri_picker", {}).get(alias, False)
+        return ret
+
+    def save_prefs(self):
+        """Save hab user_prefs."""
+        user_prefs = self.settings.resolver.user_prefs()
+        if user_prefs.enabled:
+            user_prefs.setdefault("uri_picker", {})[
+                self.alias
+            ] = self.always_ask.isChecked()
+            # Calling this setter triggers saving of user prefs
+            user_prefs.uri = self.uri_widget.uri()
+
+    def refresh(self):
+        fkwargs = {
+            "_alias": " " + self.alias if self.alias else "",
+            "alias": self.alias,
+        }
+
+        title = self.template["title"][0 if self.alias else 1]
+        title = title.format(**fkwargs)
+        self.setWindowTitle(title)
+
+        text = self.template["label"][0 if self.expired else 1]
+        text = text.format(**fkwargs)
+        self.info_label.setText(text)
+
+        if self.settings.uri is not None:
+            self.uri_widget.set_uri(self.settings.uri)
+
+        prefs = self.prefs(self.settings, self.alias)
+        self.always_ask.setVisible(prefs["enabled"])
+        if prefs["enabled"]:
+            self.always_ask.setChecked(prefs["ask"])
+
+    @classmethod
+    def should_show(cls, settings, alias=None):
+        """Checks if this dialog should be shown.
+
+        Checks for and returns True if any of the following are true:
+
+        - If user_prefs are disabled.
+        - If the user is pressing the shift key.
+        - If the user has checked the always ask checkbox for this alias.
+        - If the uri has timed out.
+        """
+        prefs = cls.prefs(settings, alias)
+        # If prefs are disabled, always show the dialog
+        if not prefs["enabled"]:
+            print("no prefs")
+            return True
+
+        # The shift key is pressed
+        # Note: Not using `keyboardModifiers` because it is not updated when
+        # calling this from the cli module.
+        modifiers = QtWidgets.QApplication.queryKeyboardModifiers()
+        if modifiers == QtCore.Qt.ShiftModifier:
+            return True
+
+        # always_ask is checked for this alias
+        if prefs["ask"]:
+            return True
+
+        # finally check if the uri has expired
+        uri_check = prefs["user_prefs"].uri_check()
+        return uri_check.timedout

--- a/hab_gui/settings.py
+++ b/hab_gui/settings.py
@@ -29,6 +29,17 @@ class Settings(QObject):
         self.resolver = resolver
         self.root_widget = root_widget
 
+    def load_entry_point(self, name, default, allow_none=False):
+        """Work function that loads the requested entry_point defined in site."""
+
+        default = {"default": default}
+        eps = self.resolver.site.entry_points_for_group(name, default=default)
+        if allow_none and (not eps or eps[0].value is None):
+            return None
+        if not eps:
+            raise ValueError(f"A valid entry_point for {name} must be defined")
+        return eps[0].load()
+
     @property
     def verbosity(self):
         """The verbosity setting used by hab_gui.

--- a/hab_gui/windows/alias_launch_window.py
+++ b/hab_gui/windows/alias_launch_window.py
@@ -99,44 +99,33 @@ class AliasLaunchWindow(QtWidgets.QMainWindow):
         self.settings.resolver.user_prefs().uri = self.uri_widget.uri()
         super().closeEvent(event)
 
-    def load_entry_point(self, name, default, allow_none=False):
-        """Work function that loads the requested entry_point."""
-
-        default = {"default": default}
-        eps = self.settings.resolver.site.entry_points_for_group(name, default=default)
-        if allow_none and (not eps or eps[0].value is None):
-            return None
-        if not eps:
-            raise ValueError(f"A valid entry_point for {name} must be defined")
-        return eps[0].load()
-
     def process_entry_points(self):
         """Loads the classes defined by the site entry_point system.
         These are later initialized by init_gui to create the UI.
         """
         # Used to launch a specific alias by `_cls_aliases_widget`
-        self._cls_alias_widget = self.load_entry_point(
+        self._cls_alias_widget = self.settings.load_entry_point(
             "hab_gui.alias.widget", "hab_gui.widgets.alias_icon_button:AliasIconButton"
         )
         # Used to display alias launch widgets
-        self._cls_aliases_widget = self.load_entry_point(
+        self._cls_aliases_widget = self.settings.load_entry_point(
             "hab_gui.aliases.widget",
             "hab_gui.widgets.alias_button_grid:AliasButtonGrid",
         )
         # Allows the user to refresh hab configuration in case it has changed.
-        self._cls_menu_button = self.load_entry_point(
+        self._cls_menu_button = self.settings.load_entry_point(
             "hab_gui.uri.menu.widget",
             "hab_gui.widgets.menu_button:MenuButton",
             allow_none=True,
         )
         # Allows the user to pin commonly used URI's
-        self._cls_uri_pin_widget = self.load_entry_point(
+        self._cls_uri_pin_widget = self.settings.load_entry_point(
             "hab_gui.uri.pin.widget",
             "hab_gui.widgets.pinned_uris_button:PinnedUriButton",
             allow_none=True,
         )
         # Interface the user uses to view and change the current URI.
-        self._cls_uri_widget = self.load_entry_point(
+        self._cls_uri_widget = self.settings.load_entry_point(
             "hab_gui.uri.widget", "hab_gui.widgets.uri_combobox:URIComboBox"
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 requires-python = ">=3.6"
 dependencies = [
     "click>=7.1.2",
-    "hab>=0.27.0",
+    "hab>=0.39.0",
     "Pygments",
     "Qt.py",
     ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 click>=7.1.2
-hab>=0.27.0
+hab>=0.39.0
 Pygments
 Qt.py


### PR DESCRIPTION
Extends hab gui launch to directly launch an alias using a gui to handle choosing the URI when required like if the user_pref has expired.

Requires https://github.com/blurstudio/hab/pull/99

When using `hab gui launch`, if you provide an AIAS instead of showing the HAB Launcher it will directly launch the requested alias without showing a UI. All trailing ARGS are passed to the launched alias. However, if the dash URI is passed it will use the URI stored in user preferences. If that URI has expired it will show the URI Picker allowing the user to choose the URI. If the shift key is pressed it will always show the URI Picker.

![cmd_t3CA9GvfB2](https://github.com/blurstudio/hab-gui/assets/2424292/d0713074-e54d-4374-9ddb-3399119e98a6)

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://github.com/PyCQA/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
