### PR TITLE
Strip trailing and leading whitespace from uri

### DIFF
--- a/hab_gui/widgets/uri_combobox.py
+++ b/hab_gui/widgets/uri_combobox.py
@@ -36,7 +36,7 @@ class URIComboBox(QtWidgets.QComboBox):
         self.set_uri(current)
 
     def uri(self):
-        return self.currentText()
+        return self.currentText().strip()
 
     def set_uri(self, uri):
         # If the uri is already an item in the combo box, select it

--- a/hab_gui/widgets/uri_line_edit.py
+++ b/hab_gui/widgets/uri_line_edit.py
@@ -24,7 +24,7 @@ class URILineEdit(QtWidgets.QLineEdit):
         pass
 
     def uri(self):
-        return self.text()
+        return self.text().strip()
 
     def set_uri(self, uri):
         self.setText(uri)


### PR DESCRIPTION
## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://github.com/PyCQA/flake8)
- [x] I have added documentation regarding my changes where necessary
- [ ] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    If user accidentally types a trailing (or leading) space, the resolved uri is incorrect, though it may not be obvious to user. This simply strips whitespace from the uri returned by the `uri` method.
-->
