### PR TITLE
Don't raise invalid requirements error to the user

### DIFF
--- a/hab_gui/widgets/alias_button_grid.py
+++ b/hab_gui/widgets/alias_button_grid.py
@@ -1,9 +1,13 @@
+import logging
+
 import hab
 from hab.errors import InvalidRequirementError
 from Qt import QtWidgets
 
 from .. import utils
 from .alias_icon_button import AliasIconButton
+
+logger = logging.getLogger(__name__)
 
 
 class AliasButtonGrid(QtWidgets.QWidget):
@@ -50,12 +54,17 @@ class AliasButtonGrid(QtWidgets.QWidget):
         try:
             cfg = resolver.resolve(self.settings.uri)
         except InvalidRequirementError as error:
+            # Show the user that there is a problem with this URI and log the
+            # exception instead of raising it. The user doesn't need to be
+            # confronted with a error dialog, and this is likely being called
+            # from a signal, so raising the exception won't stop code execution.
             msg = f"Error resolving URI: {self.settings.uri}"
             label = QtWidgets.QLabel()
             label.setText(f"{msg}\n\n{error}")
             label.setWordWrap(True)
             self.grid_layout.addWidget(label)
-            raise
+            logger.exception(msg)
+            return
 
         with hab.utils.verbosity_filter(resolver, self.settings.verbosity):
             alias_list = list(cfg.aliases.keys())


### PR DESCRIPTION
Previously this was a bad user experience. It would show the exception dialog twice, once for the AliasButtonGrid and once for the DistroPicker. The first exception didn't prevent the second because they are triggered by signals.

Now the user just see the AliasButtonGrid show the important info about the problem and the tracebacks get sent to the logger without being raised.

# Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://github.com/PyCQA/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
