### PR TITLE
Correctly filter URI's in URIComboBox when verbosity is changed

### DIFF
--- a/hab_gui/widgets/uri_combobox.py
+++ b/hab_gui/widgets/uri_combobox.py
@@ -20,6 +20,7 @@ class URIComboBox(QtWidgets.QComboBox):
         self.refresh()
 
         self.currentTextChanged.connect(self._uri_changed)
+        self.settings.verbosity_changed.connect(self.refresh)
 
     def _uri_changed(self):
         self.settings.uri = self.uri()


### PR DESCRIPTION
When you changed the verbosity level using the menu, it didn't trigger a refresh of the URIComboBox so it was showing out of date information.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://github.com/PyCQA/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
