### PR TITLE
Update user_prefs when switching the current URI

### DIFF
--- a/hab_gui/windows/alias_launch_window.py
+++ b/hab_gui/windows/alias_launch_window.py
@@ -104,11 +104,6 @@ class AliasLaunchWindow(QtWidgets.QMainWindow):
             else:
                 self.setTabOrder(self.uri_widget, self.pinned_uris)
 
-    def closeEvent(self, event):  # noqa: N802
-        """Saves the currently selected URI on close if prefs are enabled."""
-        self.settings.resolver.user_prefs().uri = self.uri_widget.uri()
-        super().closeEvent(event)
-
     def process_entry_points(self):
         """Loads the classes defined by the site entry_point system.
         These are later initialized by init_gui to create the UI.
@@ -182,9 +177,9 @@ class AliasLaunchWindow(QtWidgets.QMainWindow):
 
         self.apply_layout()
 
-        # Check for stored URI and apply it as the current text
+        # If URI is not specified use the one defined in settings
         if uri is None:
-            uri = str(self.settings.resolver.user_prefs().uri_check())
+            uri = self.settings.uri
         if uri:
             # This QTimer allows the gui to stay open even if the URI can't
             # be resolved. For example if the URI depends on a distro that is
@@ -196,7 +191,6 @@ class AliasLaunchWindow(QtWidgets.QMainWindow):
 
         # Ensure the window title always shows the currently selected URI
         self.settings.uri_changed.connect(self._update_window_title)
-        self._update_window_title(uri)
 
     @utils.cursor_override()
     def refresh_cache(self, reset_timer=True):


### PR DESCRIPTION
This ensures that the prefs are up to date with user expectations when launching an alias that uses the URI in user_prefs.

Removed unnecessary `_update_window_title` call and simplified how the saved URI is loaded on startup.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://github.com/PyCQA/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
